### PR TITLE
feat: read config for document command

### DIFF
--- a/reports/toolchains.go
+++ b/reports/toolchains.go
@@ -6,6 +6,7 @@ package reports
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 )
@@ -13,7 +14,7 @@ import (
 func ReadRevision(fn string) (string, error) {
 	f, err := os.Open(fn)
 	if err != nil {
-		return "", err
+		return "none", nil
 	}
 	defer f.Close()
 	bf := bufio.NewReader(f)
@@ -23,7 +24,9 @@ func ReadRevision(fn string) (string, error) {
 	line, err = bf.ReadString('\n')
 	line = strings.TrimSuffix(line, "\n")
 	if err != nil {
-		return "", err
+		if err != io.EOF {
+			return "", err
+		}
 	}
 
 	if line == "" {

--- a/reports/toolchains.go
+++ b/reports/toolchains.go
@@ -32,10 +32,10 @@ func ReadRevision(fn string) (string, error) {
 	return line, nil
 }
 
-func GetToolchainDetails() map[string]string {
-	toolchains := make(map[string]string)
-	toolchains["mongodb"] = "/tmp/revision.txt"
-	toolchains["python"] = "/tmp/rev_python.txt"
+func GetToolchainDetails(toolchains map[string]string) map[string]string {
+	//toolchains := make(map[string]string)
+	//toolchains["mongodb"] = "/tmp/revision.txt"
+	//toolchains["python"] = "/tmp/rev_python.txt"
 
 	toolchainDetails := make(map[string]string)
 	for name, path := range toolchains {


### PR DESCRIPTION
This PR adds support for a config file so we don't have to hardcode toolchains paths.
Format of the config is the same as checks config and it uses the same package to read it.

Sample config:
```
tests:

  - name: mongodbtoolchain
    suites:
      - ubuntu1604
    type: toolchains
    args:
      path: "/tmp/toolchains.txt"

  - name: pythontoolchain
    suites:
      - ubuntu1604
    type: toolchains
    args:
      path: "/tmp/python.txt"
```